### PR TITLE
Allow invoking against another dir than current

### DIFF
--- a/main.go
+++ b/main.go
@@ -84,6 +84,14 @@ func main() {
 		Use:     "cozypkg",
 		Short:   "Cozy wrapper around Helm and Flux CD for local development",
 		Version: Version,
+		PersistentPreRun: func(cmd *cobra.Command, args []string) {
+			if chDir != "" {
+				err := os.Chdir(chDir)
+				if err != nil {
+					log.Fatalf("could not chdir to %s: %v", chDir, err)
+				}
+			}
+		},
 	}
 	root.SetVersionTemplate("cozypkg version {{.Version}}\n")
 
@@ -92,13 +100,6 @@ func main() {
 	root.PersistentFlags().StringVarP(&chDir, "working-directory", "C", "", "Root directory of Helm chart to run against (defaults to current directory)")
 
 	_ = root.RegisterFlagCompletionFunc("namespace", completeNamespaces)
-
-	if chDir != "" {
-		err := os.Chdir(chDir)
-		if err != nil {
-			log.Fatalf("could not chdir to %s: %v", chDir, err)
-		}
-	}
 
 	root.AddCommand(
 		cmdShow(),


### PR DESCRIPTION
The previous PR was merged too quickly. The `chDir` variable is not populated at the time if execution of `main`. Moved it to `PersistentPreRun`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved the consistency of changing the working directory so it now occurs reliably before any command execution. This ensures all subcommands run in the correct directory context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->