### PR TITLE
fix(install): Respect TARGETARCH env var for cross-compilation

### DIFF
--- a/hack/install.sh
+++ b/hack/install.sh
@@ -96,14 +96,7 @@ fi
 OS=$(uname -s | tr '[:upper:]' '[:lower:]')
 
 # Detect architecture: respect TARGETARCH (Docker buildx) or ARCH env vars, fallback to uname -m
-if [ -n "$TARGETARCH" ]; then
-  ARCH="$TARGETARCH"
-elif [ -n "$ARCH" ]; then
-  # ARCH already set by environment
-  :
-else
-  ARCH=$(uname -m)
-fi
+ARCH=${TARGETARCH:-${ARCH:-$(uname -m)}}
 
 case "$ARCH" in
   x86_64|amd64) ARCH="amd64" ;;

--- a/hack/install.sh
+++ b/hack/install.sh
@@ -18,6 +18,11 @@ Usage: $0 [OPTIONS]
 Options:
   -v, --version VERSION   Install specific release (e.g. 1.4.0 or v1.4.0).
   -h, --help              Show this help and exit.
+
+Environment variables:
+  TARGETARCH              Override architecture detection (e.g. amd64, arm64).
+                          Useful for Docker buildx cross-compilation.
+  ARCH                    Alternative to TARGETARCH for architecture override.
 EOF
 }
 
@@ -89,7 +94,16 @@ else
 fi
 
 OS=$(uname -s | tr '[:upper:]' '[:lower:]')
-ARCH=$(uname -m)
+
+# Detect architecture: respect TARGETARCH (Docker buildx) or ARCH env vars, fallback to uname -m
+if [ -n "$TARGETARCH" ]; then
+  ARCH="$TARGETARCH"
+elif [ -n "$ARCH" ]; then
+  # ARCH already set by environment
+  :
+else
+  ARCH=$(uname -m)
+fi
 
 case "$ARCH" in
   x86_64|amd64) ARCH="amd64" ;;


### PR DESCRIPTION
> [!NOTE]
> Merge after #13

## Summary

Enable ARM64 cross-compilation support by respecting `TARGETARCH` environment variable in the install script.

## Problem

When building Docker images with `docker buildx` for a different architecture (e.g., building `linux/arm64` on an `amd64` host), `uname -m` returns the **build host** architecture, not the **target** architecture.

This causes the install script to download the wrong binary during cross-compilation.

## Solution

Check for `TARGETARCH` (automatically set by Docker buildx) or `ARCH` environment variables before falling back to `uname -m`:

```sh
if [ -n "$TARGETARCH" ]; then
  ARCH="$TARGETARCH"
elif [ -n "$ARCH" ]; then
  :
else
  ARCH=$(uname -m)
fi
```

## Usage

Works automatically with Docker buildx:

```dockerfile
ARG TARGETARCH
RUN wget -O- https://github.com/cozystack/cozyhr/raw/refs/heads/main/hack/install.sh | sh
```

Or manually:

```bash
TARGETARCH=arm64 ./install.sh -v 1.6.1
```

## Related

- cozystack/cozystack#1961 - ARM64 support for Generic Kubernetes