### PR TITLE
Update README to reflect current list of flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,17 +23,19 @@ Available Commands:
   get         Get one or many HelmReleases
   help        Help about any command
   list        List HelmReleases
-  reconcile   Trigger HelmRelease reconciliation (optionally its HelmChart)
+  reconcile   Trigger HelmRelease reconciliation
   resume      Resume Flux HelmRelease
   show        Render manifests like helm template
   suspend     Suspend Flux HelmRelease
   version     Print version
 
 Flags:
-  -h, --help                help for cozyhr
-      --kubeconfig string   Path to kubeconfig
-  -n, --namespace string    Kubernetes namespace (defaults to the current context)
-  -v, --version             version for cozyhr
+      --context string             Kube context
+  -h, --help                       help for cozyhr
+      --kubeconfig string          Path to kubeconfig
+  -n, --namespace string           Kubernetes namespace (defaults to the current context)
+  -v, --version                    version for cozyhr
+  -C, --working-directory string   Root directory of Helm chart to run against (defaults to current directory)
 
 Use "cozyhr [command] --help" for more information about a command.
 ```


### PR DESCRIPTION
Regenerate the README code block from the current output of running `cozyhr`, adding the `--context` and `-C` flags.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated CLI help text for the `reconcile` command.
  * Added `--context` flag documentation to the command flags list.
  * Improved formatting and alignment of CLI documentation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cozystack/cozyhr/pull/15?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->